### PR TITLE
Update to store color values as text

### DIFF
--- a/resources/js/cp_settings.js
+++ b/resources/js/cp_settings.js
@@ -8,7 +8,7 @@ deleteHandler();
 
 $('.ocp_addcolor').click(function(evt) {
     var template  = '<div class="ocp_color">'
-        template += '<input class="ocp_input" name="settings[colors][]" value="#cccccc" type="color" />'
+        template += '<input class="ocp_input" name="settings[colors][]" value="Grey" type="text" />'
         template += '<a class="ocp_delete" href="#">[delete]</a>'
         template += '</div>'
     $('.ocp_colors').append(template);

--- a/templates/_cp/settings.html
+++ b/templates/_cp/settings.html
@@ -3,7 +3,7 @@
 <div class="ocp_colors">
     {% for color in colors %}
         <div class="ocp_color">
-            <input class="ocp_input" name="colors[]" value="{{ color }}" type="color" />
+            <input class="ocp_input" name="colors[]" value="{{ color }}" type="text" />
             <a class="ocp_delete" href="#">[delete]</a>
         </div>
     {% endfor %}


### PR DESCRIPTION
Updates the plugin to store color values as text inputs vs. color picker hex values.
